### PR TITLE
Fix onlyIn, ignoreIn when using Arrays or String matcher

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -169,9 +169,9 @@ function normalizeMatcher(matcher) {
     case 'function':
       return matcher
     case 'array':
-      return node => matcher.includes(node.type)
+      return node => matcher.includes(node)
     case 'string':
-      return node => node.type == matcher
+      return node => node == matcher
   }
 }
 


### PR DESCRIPTION
Hi!

Here's a little PR to fix onlyIn / ignoreIn options when normalized from an Array or String.

The issue resides in checking `node.type` again in `normalizeMatcher` when it is already resolved at https://github.com/ianstormtaylor/slate-auto-replace/blob/master/lib/index.js#L63, leading in `node.type` being undefined in `normalizeMatcher`

Thanks for this very useful plugin :)
