### PR TITLE
Fix matches for blocks containing inlines

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,15 +80,16 @@ function AutoReplace(opts) {
   }
 
   /**
-   * Try to match a `state` with the `before` and `after` regexes.
+   * Try to match the current text of a `state` with the `before` and
+   * `after` regexes.
    *
    * @param {State} state
    * @return {Object}
    */
 
   function getMatches(state) {
-    const { startBlock, startOffset } = state
-    const { text } = startBlock
+    const { startText, startOffset } = state
+    const { text } = startText
     let after = null
     let before = null
 


### PR DESCRIPTION
Currently, if `startBlock` contains some inlines, the pattern matching logic is wrong.

I restricted the matching to the current text node. We could also preserve the matching at the current block level, like this:

```js
  /**
   * Try to match the current block of a `state` with the `before` and
   * `after` regexes.
   *
   * @param {State} state
   * @return {Object}
   */

  function getMatches(state) {
    const { startBlock, startText, startOffset } = state
    const { text } = startBlock
    let after = null
    let before = null

    const textOffset = startBlock.nodes
      .takeUntil(n => n === startText)
      .reduce(
        (offset, node) => offset + node.text.length,
        startOffset
      )

    if (opts.after) {
      const string = text.slice(textOffset)
      after = string.match(opts.after)
    }

    if (opts.before) {
      const string = text.slice(0, textOffset)
      before = string.match(opts.before)
    }

    // If both sides, require that both are matched, otherwise null.
    if (opts.before && opts.after && !before) after = null
    if (opts.before && opts.after && !after) before = null

    // Return null unless we have a match.
    if (!before && !after) return null
    return { before, after }
  }
```

But this would make the logic for `getOffsets` more complex. So I went for the simplest solution for now.

