### PR TITLE
Update plugin to be able to remove multiple offsets for capturing groups

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -132,8 +132,8 @@ function AutoReplace(opts = {}) {
     // Return null unless we have a match.
     if (!before && !after) return null
 
-    if(after) after[0] = after[0].replace(/\s+$/,"")
-    if(before) before[0] = before[0].replace(/^\s+/,"")
+    if (after) after[0] = after[0].replace(/\s+$/,"")
+    if (before) before[0] = before[0].replace(/^\s+/,"")
 
     return { before, after }
   }
@@ -152,42 +152,46 @@ function AutoReplace(opts = {}) {
     let offsets = []
     let totalRemoved = 0
 
-    if (before && before.length == 3) {
-      // Offset to remove first match
-      offsets.push({
-        start: start - before[0].length,
-        end: end - before[0].length + before[1].length,
-        total: before[1].length
-      })
-      totalRemoved += before[1].length
+    if (before) {
+      let match = before[0]
+      let startOffset = 0
+      let matchIndex = 0
 
-      // Offset to remove last match
-      offsets.push({
-        start: start - before[2].length - totalRemoved,
-        end: end - totalRemoved,
-        total: before[2].length
-      })
+      before.slice(1, before.length)
+        .forEach(function (current) {
+          matchIndex = match.indexOf(current, matchIndex)
+          startOffset = start - totalRemoved + matchIndex - match.length
 
-      return offsets
+          offsets.push({
+            start: startOffset,
+            end: startOffset + current.length,
+            total: current.length
+          })
+
+          totalRemoved += current.length
+          matchIndex += current.length
+        });
     }
 
-    if (before && before.length == 2) {
-      // Offset to remove first match
-      offsets.push({
-        start: start - before[0].length,
-        end: end - before[0].length + before[1].length,
-        total: before[1].length
-      })
-      totalRemoved += before[1].length
-    }
+    if(after) {
+      let match = after[0]
+      let startOffset = 0
+      let matchIndex = 0
 
-    if(after && after.length == 2) {
-      // Offset to remove last match
-      offsets.push({
-        start: start - totalRemoved + after[0].length - after[1].length,
-        end: end - totalRemoved + after[0].length,
-        total: 0
-      })
+      after.slice(1, after.length)
+        .forEach(function (current) {
+          matchIndex = match.indexOf(current, matchIndex)
+          startOffset = start - totalRemoved + matchIndex
+
+          offsets.push({
+            start: startOffset,
+            end: startOffset + current.length,
+            total: 0
+          })
+
+          totalRemoved += current.length
+          matchIndex += current.length
+        })
     }
 
     return offsets


### PR DESCRIPTION
Based on what we talked about in https://github.com/ianstormtaylor/slate-auto-replace/issues/8, I discovered today that the plugin does not remove each individual capturing group match, but only an offset based on the first before and after match. This makes it impossible to deal with clearing mark style formatting characters surrounding text that is already formatted.

In order to get nested marks to work, I made changes to `replace()`, `getOffset`, and `getMatches()` so that multiple offset deletions would occur instead of just a single removal when dealing with more than one regex matching group (i.e. `(\*{2})[^\*]+(\*)$`). 

The primary benefit of these changes is that nested marking now works as you type.

![Example](http://i.giphy.com/26BGKWGpd0AFlU5ag.gif)

**Of note**
I ended up trimming whitespace in `getMatches()` because JS doesn't support negative lookbehinds for verifying something like `*emphasis*` syntax (i.e. `(?<!\*)(\*{1})[^\*]+$` doesn't work but `(?:^|\s)(\*{1})[^\*]+$` includes whitespace characters at the beginning of the full match)

**Example usage**

```
//
// Quote block
//
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: 'space',
  before: /^(>)$/,
  transform: transform => quotePlugin
    .transforms
    .wrapInBlockquote(transform)
}),

//
// Strong marks
//
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: '*',
  before: /(\*{2})[^\*]+(\*)$/,
  transform: (transform, e, data, matches, editor) => {
    var inputLength = matches.before[0].length - 3;

    return transform
      .extendBackward(inputLength)
      .toggleMark(STRONG_MARK)
      .collapseToEnd()
      .removeMark(STRONG_MARK)
  }
}),
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: '*',
  before: /(\*{1})$/,
  after: /^[^\*]+(\*{2})/,
  transform: (transform, e, data, matches) => {
    var inputLength = matches.after[0].length - 2;

    return transform
      .extendForward(inputLength)
      .toggleMark(STRONG_MARK)
      .collapseToStart()
      .removeMark(STRONG_MARK)
  }
}),
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: '_',
  before: /(_{2})[^_]+(_)$/,
  transform: (transform, e, data, matches) => {
    var inputLength = matches.before[0].length - 3;

    return transform
      .extendBackward(inputLength)
      .toggleMark(STRONG_MARK)
      .collapseToEnd()
      .removeMark(STRONG_MARK)
  }
}),
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: '_',
  before: /(_{1})$/,
  after: /^[^_]+(_{2})/,
  transform: (transform, e, data, matches) => {
    var inputLength = matches.after[0].length - 2;

    return transform
      .extendForward(inputLength)
      .toggleMark(STRONG_MARK)
      .collapseToStart()
      .removeMark(STRONG_MARK)
  }
}),

//
// Emphasis marks
//
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: '*',
  before: /(?:^|\s)(\*{1})[^\*]+$/,
  transform: (transform, e, data, matches) => {
    var inputLength = matches.before[0].length - 1

    return transform
      .extendBackward(inputLength)
      .toggleMark(EMPHASIS_MARK)
      .collapseToEnd()
      .removeMark(EMPHASIS_MARK)
  }
}),
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: '*',
  after: /^[^\*]+(\*{1})(?:$|\s)/,
  transform: (transform, e, data, matches) => {
    var inputLength = matches.after[0].length - 1

    return transform
      .extendForward(inputLength)
      .toggleMark(EMPHASIS_MARK)
      .collapseToStart()
      .removeMark(EMPHASIS_MARK)
  }
}),
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: '_',
  before: /(?:^|\s)(_{1})[^_]+$/,
  transform: (transform, e, data, matches) => {
    var inputLength = matches.before[0].length - 1

    return transform
      .extendBackward(inputLength)
      .toggleMark(EMPHASIS_MARK)
      .collapseToEnd()
      .removeMark(EMPHASIS_MARK)
  }
}),
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: '_',
  after: /^[^_]+(_{1})(?:$|\s)/,
  transform: (transform, e, data, matches) => {
    var inputLength = matches.after[0].length - 1

    return transform
      .extendForward(inputLength)
      .toggleMark(EMPHASIS_MARK)
      .collapseToStart()
      .removeMark(EMPHASIS_MARK)
  }
}),

//
// Strikethrough marks
//
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: '~',
  before: /(\~{2})[^\~]+(\~)$/,
  transform: (transform, e, data, matches) => {
    var inputLength = matches.before[0].length - 3

    return transform
      .extendBackward(inputLength)
      .toggleMark(STRIKE_MARK)
      .collapseToEnd()
      .removeMark(STRIKE_MARK)
  }
}),
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: '~',
  before: /(\~{1})$/,
  after: /^[^\~]+(\~{2})/,
  transform: (transform, e, data, matches) => {
    var inputLength = matches.after[0].length - 2

    return transform
      .extendForward(inputLength)
      .toggleMark(STRIKE_MARK)
      .collapseToStart()
      .removeMark(STRIKE_MARK)
  }
}),

//
// Code marks
//
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: '`',
  before: /(\`{1})[^\`]+$/,
  transform: (transform, e, data, matches) => {
    var inputLength = matches.before[0].length - 1

    return transform
      .extendBackward(inputLength)
      .toggleMark(CODE_MARK)
      .collapseToEnd()
      .removeMark(CODE_MARK)
  }
}),
AutoReplaceText({
  ignoreIn: CODE_BLOCK,
  trigger: '`',
  after: /^[^\`]+(\`{1})/,
  transform: (transform, e, data, matches) => {
    var inputLength = matches.after[0].length - 1

    return transform
      .extendForward(inputLength)
      .toggleMark(CODE_MARK)
      .collapseToStart()
      .removeMark(CODE_MARK)
  }
}),
```