### PR TITLE
Update getOffsets to ignore undefined capture groups.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -158,6 +158,8 @@ function AutoReplace(opts = {}) {
       let matchIndex = 0
 
       before.slice(1, before.length).forEach((current) => {
+        if(current === undefined) return
+
         matchIndex = match.indexOf(current, matchIndex)
         startOffset = start - totalRemoved + matchIndex - match.length
 
@@ -178,6 +180,8 @@ function AutoReplace(opts = {}) {
       let matchIndex = 0
 
       after.slice(1, after.length).forEach((current) => {
+        if(current === undefined) return
+
         matchIndex = match.indexOf(current, matchIndex)
         startOffset = start - totalRemoved + matchIndex
 


### PR DESCRIPTION
Given not all regular expressions are created equal, the following checks ensure any undefined capture groups are ignored when getOffsets is called.