### PR TITLE
Update deprecated moveToOffsets method calls to moveOffsetsTo.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -88,13 +88,13 @@ function AutoReplace(opts = {}) {
 
     offsets.forEach((offset) => {
       currentTransform
-        .moveToOffsets(offset.start, offset.end)
+        .moveOffsetsTo(offset.start, offset.end)
         .delete()
       totalRemoved += offset.total
     })
 
     startOffset -= totalRemoved
-    currentTransform.moveToOffsets(startOffset, startOffset)
+    currentTransform.moveOffsetsTo(startOffset, startOffset)
 
     return currentTransform
       .call(transform, e, data, matches, editor)


### PR DESCRIPTION
This removes the warnings for the deprecation of the `moveToOffsets()` method.

See deprecation notice at v0.17.0: https://github.com/ianstormtaylor/slate/blob/3c49ca8ed15143c396d1a53c9df45a7bf79ff963/History.md#0170--february-27-2017